### PR TITLE
Settings: remove theme switch from slim action shortcuts

### DIFF
--- a/res/values/slim_arrays.xml
+++ b/res/values/slim_arrays.xml
@@ -312,7 +312,6 @@
         <item>@string/shortcut_action_power_menu</item>
         <item>@string/shortcut_action_torch</item>
         <item>@string/shortcut_action_expanded_desktop</item>
-        <item>@string/shortcut_action_theme_switch</item>
         <item>@string/shortcut_action_pie</item>
         <item>@string/shortcut_action_nav_bar</item>
         <item>@string/shortcut_action_camera</item>
@@ -345,7 +344,6 @@
         <item>**power_menu**</item>
         <item>**torch**</item>
         <item>**expanded_desktop**</item>
-        <item>**theme_switch**</item>
         <item>**pie**</item>
         <item>**nav_bar**</item>
         <item>**camera**</item>


### PR DESCRIPTION
Change-Id: Ieed0cd5557f57914948e72c9c24099a01d8433f7