### PR TITLE
Settings: fix up SlimAction shortcut icons (2/2)

### DIFF
--- a/res/values/slim_arrays.xml
+++ b/res/values/slim_arrays.xml
@@ -641,8 +641,10 @@
         <item>@string/shortcut_action_power</item>
         <item>@string/shortcut_action_screenshot</item>
         <item>@string/shortcut_action_search</item>
+        <item>@string/shortcut_action_voice_search</item>
         <item>@string/shortcut_action_torch</item>
         <item>@string/shortcut_action_expanded_desktop</item>
+        <item>@string/shortcut_action_camera</item>
         <item>@string/shortcut_action_none</item>
     </string-array>
 
@@ -662,8 +664,10 @@
         <item>**power**</item>
         <item>**screenshot**</item>
         <item>**search**</item>
+        <item>**voice_search**</item>
         <item>**torch**</item>
         <item>**expanded_desktop**</item>
+        <item>**camera**</item>
         <item>**null**</item>
     </string-array>
 

--- a/src/com/android/settings/CreateSlimShortcut.java
+++ b/src/com/android/settings/CreateSlimShortcut.java
@@ -69,7 +69,9 @@ public class CreateSlimShortcut extends Activity {
                 Drawable icon = ActionHelper.getActionIconImage(
                         CreateSlimShortcut.this, dialogValues[item], null);
                 Intent intent = new Intent();
-                intent.putExtra(Intent.EXTRA_SHORTCUT_ICON, ImageHelper.drawableToBitmap(icon));
+                intent.putExtra(Intent.EXTRA_SHORTCUT_ICON,
+                        ImageHelper.drawableToShortcutIconBitmap(
+                        getApplicationContext(), icon, 36 /* dp */));
                 intent.putExtra(Intent.EXTRA_SHORTCUT_NAME, dialogEntries[item]);
                 intent.putExtra(Intent.EXTRA_SHORTCUT_INTENT, shortcutIntent);
                 setResult(RESULT_OK, intent);


### PR DESCRIPTION
patchset: use dp instead of px to properly size icon

patchset: add camera and voice_search to action arrays

Change-Id: Id03346d02a191fe5d44c0b54fc1d210bee20ac01